### PR TITLE
Set the notification window to hidden

### DIFF
--- a/CWStatusBarNotification/CWStatusBarNotification.m
+++ b/CWStatusBarNotification/CWStatusBarNotification.m
@@ -405,6 +405,7 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
         } completion:^(BOOL finished) {
             [self.notificationLabel removeFromSuperview];
             [self.statusBarView removeFromSuperview];
+            [self.notificationWindow setHidden:YES];
             self.notificationWindow = nil;
             self.notificationLabel = nil;
             self.notificationIsShowing = NO;


### PR DESCRIPTION
By setting the hidden flag, the OS will poll the status bar style of the original view controller. Without this flag, the status bar will always become black after the notification animation, because it polls the new `UIViewController` instance created on line 286. This was causing a weird effect in my app, which has a white status bar (`UIStatusBarStyleLightContent`) at times.
