### PR TITLE
Fixes issue window hitTest on iOS 7

### DIFF
--- a/CWStatusBarNotification/CWStatusBarNotification.m
+++ b/CWStatusBarNotification/CWStatusBarNotification.m
@@ -21,7 +21,13 @@
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
-    if (point.y > 0 && point.y < [UIApplication sharedApplication].statusBarFrame.size.height) {
+    CGFloat height;
+    if (SYSTEM_VERSION_LESS_THAN(@"8.0") && UIDeviceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation))
+        height = [UIApplication sharedApplication].statusBarFrame.size.width;
+    else
+        height = [UIApplication sharedApplication].statusBarFrame.size.height;
+    
+    if (point.y > 0 && point.y < height) {
         return [super hitTest:point withEvent:event];
     }
     


### PR DESCRIPTION
The landscape window coordinate changes broke the CWWindowContainer
hitTest function. This now handles iOS 7/8 gracefully.
