### PR TITLE
Adding dismissNotificationWithCompletion method

### DIFF
--- a/CWStatusBarNotification/CWStatusBarNotification.h
+++ b/CWStatusBarNotification/CWStatusBarNotification.h
@@ -61,5 +61,6 @@ typedef NS_ENUM(NSInteger, CWNotificationAnimationType) {
 - (void)displayNotificationWithView:(UIView *)view forDuration:(CGFloat)duration;
 - (void)displayNotificationWithView:(UIView *)view completion:(void (^)(void))completion;
 - (void)dismissNotification;
+- (void)dismissNotificationWithCompletion:(void(^)(void))completion;
 
 @end

--- a/CWStatusBarNotification/CWStatusBarNotification.m
+++ b/CWStatusBarNotification/CWStatusBarNotification.m
@@ -495,6 +495,11 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
 
 - (void)dismissNotification
 {
+    [self dismissNotificationWithCompletion:nil];
+}
+
+- (void)dismissNotificationWithCompletion:(void (^)(void))completion
+{
     if (self.notificationIsShowing) {
         cancel_delayed_block(self.dismissHandle);
         self.notificationIsDismissing = YES;
@@ -512,7 +517,14 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
             self.notificationIsDismissing = NO;
             [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
             [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillChangeStatusBarFrameNotification object:nil];
+            if (completion) {
+                completion();
+            }
         }];
+    } else {
+        if (completion) {
+            completion();
+        }
     }
 }
 


### PR DESCRIPTION
Added dismissNotificationWithCompletion method. Left the old method
without completion intact for backwards compatibility.
