### PR TITLE
Make the completion handler optional

### DIFF
--- a/CWStatusBarNotification/CWStatusBarNotification.swift
+++ b/CWStatusBarNotification/CWStatusBarNotification.swift
@@ -382,8 +382,8 @@ class CWStatusBarNotification : NSObject {
                 }, completion: { (finished : Bool) -> () in
                     var delayInSeconds = Double(self.notificationLabel.scrollTime())
                     performClosureAfterDelay(delayInSeconds, {
-                        if completion() != nil {
-                            completion()!
+                        if let completion = completion {
+                            completion()
                         }
                     })
                 })


### PR DESCRIPTION
Make the ? operator apply to the closure by putting in an extra set of parentheses.
