### PR TITLE
preferredStatusBarStyle

### DIFF
--- a/CWStatusBarNotification/CWStatusBarNotification.h
+++ b/CWStatusBarNotification/CWStatusBarNotification.h
@@ -20,6 +20,10 @@ typedef void(^CWCompletionBlock)(void);
 
 @end
 
+@interface CWViewController : UIViewController
+@property (nonatomic) UIStatusBarStyle preferredStatusBarStyle;
+@end
+
 @interface CWStatusBarNotification : NSObject
 
 typedef NS_ENUM(NSInteger, CWNotificationStyle) {
@@ -59,6 +63,7 @@ typedef NS_ENUM(NSInteger, CWNotificationAnimationType) {
 @property (nonatomic) BOOL notificationIsDismissing;
 
 @property (strong, nonatomic) CWWindowContainer *notificationWindow;
+@property (nonatomic) UIStatusBarStyle preferredStatusBarStyle;
 
 - (void)displayNotificationWithMessage:(NSString *)message forDuration:(CGFloat)duration;
 - (void)displayNotificationWithMessage:(NSString *)message completion:(void (^)(void))completion;

--- a/CWStatusBarNotification/CWStatusBarNotification.m
+++ b/CWStatusBarNotification/CWStatusBarNotification.m
@@ -38,6 +38,15 @@
 
 @end
 
+@implementation CWViewController
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return _preferredStatusBarStyle;
+}
+
+@end
+
 # pragma mark - dispatch after with cancellation
 // adapted from: https://github.com/Spaceman-Labs/Dispatch-Cancel
 
@@ -172,6 +181,7 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
         self.notificationAnimationType = CWNotificationAnimationTypeReplace;
         self.notificationIsDismissing = NO;
         self.isCustomView = NO;
+        self.preferredStatusBarStyle = UIStatusBarStyleDefault;
 
         // create tap recognizer
         self.tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(notificationTapped:)];
@@ -340,7 +350,9 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
     self.notificationWindow.userInteractionEnabled = YES;
     self.notificationWindow.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.notificationWindow.windowLevel = UIWindowLevelStatusBar;
-    self.notificationWindow.rootViewController = [UIViewController new];
+    CWViewController *rootViewController = [[CWViewController alloc] init];
+    rootViewController.preferredStatusBarStyle = self.preferredStatusBarStyle;
+    self.notificationWindow.rootViewController = rootViewController;
     self.notificationWindow.notificationHeight = [self getNotificationLabelHeight];
 }
 


### PR DESCRIPTION
Are there any plans/suggestions on setting the status bar color when animating out? I'm using CWStatusBarNotification on an app that uses a white status bar (`UIStatusBarStyle.LightContent`). The problem is that as the notification label animates out, there's a black status bar visible for a fraction of a second before becoming white again. It looks like that's due to CWWindowContainer overlaying the white status bar. I just wanted to ask about a fix before trying to do it myself.

Thanks!