### PR TITLE
Added the ability to hand over supportededInterfaceOrientations

### DIFF
--- a/CWStatusBarNotification/CWStatusBarNotification.h
+++ b/CWStatusBarNotification/CWStatusBarNotification.h
@@ -22,6 +22,7 @@ typedef void(^CWCompletionBlock)(void);
 
 @interface CWViewController : UIViewController
 @property (nonatomic) UIStatusBarStyle preferredStatusBarStyle;
+@property (nonatomic, setter=setSupportedInterfaceOrientations:) NSInteger supportedInterfaceOrientations;
 @end
 
 @interface CWStatusBarNotification : NSObject
@@ -56,6 +57,7 @@ typedef NS_ENUM(NSInteger, CWNotificationAnimationType) {
 @property (copy, nonatomic) CWCompletionBlock notificationTappedBlock;
 
 @property (nonatomic) CWNotificationStyle notificationStyle;
+@property (nonatomic) NSInteger supportedInterfaceOrientations;
 @property (nonatomic) CWNotificationAnimationStyle notificationAnimationInStyle;
 @property (nonatomic) CWNotificationAnimationStyle notificationAnimationOutStyle;
 @property (nonatomic) CWNotificationAnimationType notificationAnimationType;

--- a/CWStatusBarNotification/CWStatusBarNotification.m
+++ b/CWStatusBarNotification/CWStatusBarNotification.m
@@ -38,11 +38,27 @@
 
 @end
 
+@interface CWViewController()
+
+@property (nonatomic, assign) NSInteger _cwViewControllerSupportedInterfaceOrientation;
+
+@end
+
 @implementation CWViewController
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
     return _preferredStatusBarStyle;
+}
+
+- (void)setSupportedInterfaceOrientations:(NSInteger)supportedInterfaceOrientations
+{
+    self._cwViewControllerSupportedInterfaceOrientation = supportedInterfaceOrientations;
+}
+
+- (NSUInteger)supportedInterfaceOrientations
+{
+    return self._cwViewControllerSupportedInterfaceOrientation;
 }
 
 @end
@@ -182,6 +198,7 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
         self.notificationIsDismissing = NO;
         self.isCustomView = NO;
         self.preferredStatusBarStyle = UIStatusBarStyleDefault;
+        self.supportedInterfaceOrientations = UIInterfaceOrientationMaskAll;
 
         // create tap recognizer
         self.tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(notificationTapped:)];
@@ -351,6 +368,7 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
     self.notificationWindow.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.notificationWindow.windowLevel = UIWindowLevelStatusBar;
     CWViewController *rootViewController = [[CWViewController alloc] init];
+    [rootViewController setSupportedInterfaceOrientations:self.supportedInterfaceOrientations];
     rootViewController.preferredStatusBarStyle = self.preferredStatusBarStyle;
     self.notificationWindow.rootViewController = rootViewController;
     self.notificationWindow.notificationHeight = [self getNotificationLabelHeight];


### PR DESCRIPTION
 for CWStatusBarNotification. This is optional and the standard value is to support all orientation masks.

We operate a Portrait only app and we can handle this now with full control. Maybe it's something other users will also need.