### PR TITLE
Fix calculation of navbar height

### DIFF
--- a/CWStatusBarNotification/CWStatusBarNotification.m
+++ b/CWStatusBarNotification/CWStatusBarNotification.m
@@ -272,7 +272,7 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
 
 - (CGFloat)getNavigationBarHeight
 {
-    if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation) ||
+    if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation) ||
         UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
         return 44.0f;
     }


### PR DESCRIPTION
`2.2.4` appears to have introduced a regression in how the nav bar height is being calculated. This fixes the calculation.