### PR TITLE
Quick fix for lack of NSAttributedString support. Could be improved.

### DIFF
--- a/CWStatusBarNotification/CWStatusBarNotification.m
+++ b/CWStatusBarNotification/CWStatusBarNotification.m
@@ -495,10 +495,10 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
     }
 }
 
-- (void)displayNotificationWithAttributedString:(NSAttributedString *)attributedString completion:(void (^)(void))completion
+- (void)displayNotificationWithAttributedText:(NSAttributedString *)attributedText completion:(void (^)(void))completion
 {
-    [self displayNotificationWithMessage:[attributedString string] completion:completion];
-    [[self notificationLabel] setAttributedText:attributedString];
+    [self displayNotificationWithMessage:[attributedText string] completion:completion];
+    [[self notificationLabel] setAttributedText:attributedText];
     
 }
 
@@ -582,10 +582,10 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
     }];
 }
 
-- (void)displayNotificationWithAttributedString:(NSAttributedString *)attributedString forDuration:(CGFloat)duration
+- (void)displayNotificationWithAttributedText:(NSAttributedString *)attributedText forDuration:(CGFloat)duration
 {
-    [self displayNotificationWithMessage:[attributedString string] forDuration:duration];
-    [[self notificationLabel] setAttributedText:attributedString];
+    [self displayNotificationWithMessage:[attributedText string] forDuration:duration];
+    [[self notificationLabel] setAttributedText:attributedText];
     
 }
 

--- a/CWStatusBarNotification/CWStatusBarNotification.m
+++ b/CWStatusBarNotification/CWStatusBarNotification.m
@@ -495,6 +495,13 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
     }
 }
 
+- (void)displayNotificationWithAttributedString:(NSAttributedString *)attributedString completion:(void (^)(void))completion
+{
+    [self displayNotificationWithMessage:[attributedString string] completion:completion];
+    [[self notificationLabel] setAttributedText:attributedString];
+    
+}
+
 - (void)displayNotificationWithView:(UIView *)view completion:(void (^)(void))completion
 {
     if (!self.notificationIsShowing) {
@@ -573,6 +580,13 @@ static void cancel_delayed_block(CWDelayedBlockHandle delayedHandle)
             [self dismissNotification];
         });
     }];
+}
+
+- (void)displayNotificationWithAttributedString:(NSAttributedString *)attributedString forDuration:(CGFloat)duration
+{
+    [self displayNotificationWithMessage:[attributedString string] forDuration:duration];
+    [[self notificationLabel] setAttributedText:attributedString];
+    
 }
 
 - (void)displayNotificationWithView:(UIView *)view forDuration:(CGFloat)duration


### PR DESCRIPTION
I noticed that there was only a way to present plain strings. I personally like to display attributed strings in situations like this, as it allows you to do bold fonts or different styles/formatting.

I added a quick way to do this, but it's not the cleanest implementation. However, having these functions in place for the future would be nice when eventually refactoring code.