### PR TITLE
Fixed crash for tapping on status bar notification

### DIFF
--- a/CWStatusBarNotification/CWStatusBarNotification/CWStatusBarNotification.swift
+++ b/CWStatusBarNotification/CWStatusBarNotification/CWStatusBarNotification.swift
@@ -199,7 +199,7 @@ public class CWStatusBarNotification : NSObject {
     
     // MARK: - on tap
     
-    private func notificationTapped(recognizer : UITapGestureRecognizer) {
+    func notificationTapped(recognizer : UITapGestureRecognizer) {
         self.notificationTappedClosure()
     }
     


### PR DESCRIPTION
Selectors cannot be private in Swift.